### PR TITLE
update python building instructions with the correct path

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ To build **Python** bindings as a wheel, you need to install [maturin](https://g
 Run the following to build the wheel:
 
 ```bash
-$ cd pylibtashkeel
+$ cd crates/python
 $ python3 -m venv .venv
 $ source .venv/bin/activate
 $ pip install maturin


### PR DESCRIPTION
As I followed the `README` instructions, I found there was Just a tiny change to make in the building stage instructions for python. This matches the current structure of the repo. Thanks.