### PR TITLE
Lock the version of ort and ort-sys.

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://github.com/mush42/libtashkeel"
 [features]
 default = ["ort", "rayon"]
 rayon = ["dep:rayon"]
-ort = ["dep:ort"]
+ort = ["dep:ort", "dep:ort-sys"]
 ort-dylib = ["ort/load-dynamic"]
 
 [dependencies]
@@ -25,8 +25,12 @@ serde_json = "1.0.89"
 thiserror = "1.0.47"
 
 [dependencies.ort]
-version = "2.0.0-rc.9"
+version = "=2.0.0-rc.9"
+optional = true
+
+[dependencies.ort-sys]
+version = "=2.0.0-rc.9"
 optional = true
 
 [dev-dependencies.ort]
-version = "2.0.0-rc.9"
+version = "=2.0.0-rc.9"


### PR DESCRIPTION
The API changed a lot between 2.0.0-rc.9 and 2.0.0-rc.10.